### PR TITLE
feat(33): send previous room id via websocket

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -51,10 +51,10 @@ functions:
       - websocket:
           route: $connect
           # Only if we want authenticated connections
-          authorizer:
-            name: auth
-            identitySource:
-              - 'route.request.header.Auth'
+          #authorizer:
+            #name: auth
+            #identitySource:
+              #- 'route.request.header.Auth'
   disconnect:
     handler: functions/disconnect.main
     iamRoleStatementsInherit: true

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -50,11 +50,6 @@ functions:
     events:
       - websocket:
           route: $connect
-          # Only if we want authenticated connections
-          #authorizer:
-            #name: auth
-            #identitySource:
-              #- 'route.request.header.Auth'
   disconnect:
     handler: functions/disconnect.main
     iamRoleStatementsInherit: true

--- a/extension/.gitignore
+++ b/extension/.gitignore
@@ -5,3 +5,4 @@ dist
 .sass-cache
 .DS_Store
 build
+env/common.js

--- a/extension/README.md
+++ b/extension/README.md
@@ -16,6 +16,7 @@
 
 -   You might need to specify different data variables based on your environment. For example, you might want to use a localhost API endpoint during development and a production API endpoint once the extension is submitted to the appstore. You can specify such data in the json files inside `config` directory.
 -   You can also set custom data variables based on the platform (different variable for Chrome, FF, Opera).
+-   You can also set you own environment variables, by making your own `env/common.js` from `env/common.js.example`, and filling in the placeholders, while keeping the single and double quotes surrounding your variable
 
 ## Installation
 

--- a/extension/env/common.js.example
+++ b/extension/env/common.js.example
@@ -1,3 +1,12 @@
 module.exports = {
-    WS_URL: '""'
+    prod: {
+        WS_URL: '""'
+    },
+    dev: {
+        WS_URL: '""'
+    },
+    test: {
+        WS_URL: '""'
+    },
+
 }

--- a/extension/env/common.js.example
+++ b/extension/env/common.js.example
@@ -1,0 +1,3 @@
+module.exports = {
+    WS_URL: '""'
+}

--- a/extension/env/development.env.js
+++ b/extension/env/development.env.js
@@ -1,6 +1,6 @@
 var merge = require("webpack-merge");
 var prodEnv = require("./production.env");
-var common = require("./common");
+var common = require("./common").dev;
 
 module.exports = merge(prodEnv, {
     NODE_ENV: '"development"',

--- a/extension/env/development.env.js
+++ b/extension/env/development.env.js
@@ -1,8 +1,10 @@
-var merge = require('webpack-merge')
-var prodEnv = require('./production.env')
+var merge = require("webpack-merge");
+var prodEnv = require("./production.env");
+var common = require("./common");
 
 module.exports = merge(prodEnv, {
-  NODE_ENV: '"development"',
-  HOST: '"127.0.0.1:8000"',
-  USE_API_MOCK: 'false'
-})
+    NODE_ENV: '"development"',
+    HOST: '"127.0.0.1:8000"',
+    USE_API_MOCK: "false",
+    ...common,
+});

--- a/extension/env/production.env.js
+++ b/extension/env/production.env.js
@@ -1,5 +1,8 @@
+var common = require("./common").prod;
+
 module.exports = {
-  NODE_ENV: '"production"',
-  HOST: '"prod-host:80"',
-  USE_API_MOCK: 'false'
-}
+    NODE_ENV: '"production"',
+    HOST: '"prod-host:80"',
+    USE_API_MOCK: "false",
+    ...common,
+};

--- a/extension/env/test.env.js
+++ b/extension/env/test.env.js
@@ -1,8 +1,10 @@
-var merge = require('webpack-merge')
-var devEnv = require('./dev.env')
+var merge = require("webpack-merge");
+var devEnv = require("./dev.env");
+var common = require("./common").test;
 
 module.exports = merge(devEnv, {
-  NODE_ENV: '"testing"',
-  HOST: '"localhost:8000"',
-  USE_API_MOCK: 'true'
-})
+    NODE_ENV: '"testing"',
+    HOST: '"localhost:8000"',
+    USE_API_MOCK: "true",
+    ...common,
+});

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -1,5 +1,6 @@
 import { browser, Runtime } from "webextension-polyfill-ts";
 import { MessageType } from "../types";
+import WebSocketClient from "./websocket-client";
 
 const log = require("debug")("ext:background");
 
@@ -8,15 +9,37 @@ async function polling() {
     log(`Polling`);
 }
 
-async function fetchPreviousRoomId() {
+async function fetchPreviousRoomId(): Promise<{ [s: string]: any }> {
     // Maybe boot a random roomId on first load ?
     return browser.storage.sync.get({ roomId: undefined });
 }
-// TODO : Connect to previous roomId using websocket
+
+const wsClient: WebSocketClient = new WebSocketClient(process.env.WS_URL || "");
+
+async function connectToWebSocket() {
+    try {
+        await wsClient.connect();
+        console.log("Connected to WebSocket");
+        wsClient.getWebSocket().onmessage = (event: any) => {
+            // Since the messages are supposed to be in JSON format, should be: JSON.parse(event.data)
+            const receivedMsg = event.data;
+            console.log(receivedMsg);
+        };
+    } catch (e) {
+        console.log(e);
+    }
+}
+
+// Connect to previous roomId using websocket
+async function connectToPreviousRoom() {
+    const roomId = await fetchPreviousRoomId();
+    wsClient.getWebSocket().send(JSON.stringify({ roomId }));
+}
 
 var portFromCS: Runtime.Port;
 
 const connected = (p: Runtime.Port) => {
+    console.log(process.env.NODE_ENV);
     portFromCS = p;
     console.log("[BG] Content Script connected");
     portFromCS.postMessage({
@@ -30,7 +53,8 @@ const connected = (p: Runtime.Port) => {
             case MessageType.CHANGE_ROOM: {
                 const { roomId } = m;
                 browser.storage.sync.set({ roomId });
-                // TODO : Connect to roomId using websocket
+                // Connect to roomId using websocket
+                connectToPreviousRoom();
                 console.log(`[BG] Joined WatchWithMe room ${roomId}`);
                 break;
             }
@@ -40,5 +64,7 @@ const connected = (p: Runtime.Port) => {
             }
         }
     });
+
+    connectToWebSocket();
 };
 browser.runtime.onConnect.addListener(connected);

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -23,7 +23,7 @@ async function connectToWebSocket() {
         wsClient.getWebSocket().onmessage = (event: any) => {
             // Since the messages are supposed to be in JSON format, should be: JSON.parse(event.data)
             const receivedMsg = event.data;
-            console.log(receivedMsg);
+            console.log(`[WS-S] ${receivedMsg}`);
         };
     } catch (e) {
         console.log(e);
@@ -33,13 +33,14 @@ async function connectToWebSocket() {
 // Connect to previous roomId using websocket
 async function connectToPreviousRoom() {
     const roomId = await fetchPreviousRoomId();
-    wsClient.getWebSocket().send(JSON.stringify({ roomId }));
+    wsClient
+        .getWebSocket()
+        .send(JSON.stringify({ type: MessageType.CHANGE_ROOM, roomId }));
 }
 
 var portFromCS: Runtime.Port;
 
 const connected = (p: Runtime.Port) => {
-    console.log(process.env.NODE_ENV);
     portFromCS = p;
     console.log("[BG] Content Script connected");
     portFromCS.postMessage({

--- a/extension/src/background/websocket-client.ts
+++ b/extension/src/background/websocket-client.ts
@@ -1,0 +1,32 @@
+export default class WebSocketClient {
+    private host: string;
+    private webSocket!: WebSocket;
+
+    public constructor(host: string) {
+        this.host = host;
+    }
+
+    public getWebSocket(): WebSocket {
+        return this.webSocket;
+    }
+
+    public connect(): Promise<void> {
+        return new Promise((resolve) => {
+            this.webSocket = new WebSocket(this.host);
+
+            this.webSocket.onopen = () => {
+                this.webSocket.send(
+                    JSON.stringify({ message: "[WS] Connected to server" })
+                );
+                resolve();
+            };
+            this.webSocket.onclose = () => {};
+        });
+    }
+
+    public close() {
+        if (this.webSocket) {
+            this.webSocket.close();
+        }
+    }
+}

--- a/extension/src/background/websocket-client.ts
+++ b/extension/src/background/websocket-client.ts
@@ -16,7 +16,7 @@ export default class WebSocketClient {
 
             this.webSocket.onopen = () => {
                 this.webSocket.send(
-                    JSON.stringify({ message: "[WS] Connected to server" })
+                    JSON.stringify({ message: "[WS-E] Connected to server" })
                 );
                 resolve();
             };


### PR DESCRIPTION
### Added
- Function to open a Websocket connection and send the previous room ID to AWS
- In `/env`: a `common.js.example` sample file, to be edited just like an env file. The file will be exported into `${env}.env.js` and injected into `process.env`